### PR TITLE
fix for undefined index "hero"

### DIFF
--- a/index.php
+++ b/index.php
@@ -113,7 +113,8 @@ return [
             }
 
             $classes = [
-                'navbar' => 'tm-navbar'
+                'navbar' => 'tm-navbar',
+                'hero' => '',
             ];
 
             $sticky = [
@@ -123,7 +124,7 @@ return [
             ];
 
             if ($event['hero_viewport']) {
-                $classes['hero'] = 'tm-hero-height';
+                $classes['hero'] .= 'tm-hero-height';
             }
 
             // Sticky overlay navbar if hero position exists


### PR DESCRIPTION
With the following settings in the page I got this php notice:

Notice: Undefined index: hero in /var/www/packages/pagekit/theme-one/index.php on line 154

Hero Image: 
[ ] Full viewport height
[X]  Invert colors
[ ]  Transparent navbar as overlay

Now, it's fixed.
