### PR TITLE
Add theme image to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # One Theme
 
 Pagekit's default theme.
+
+![One Theme Screenshot](image.jpg)


### PR DESCRIPTION
I propose to display `image.jpg` not only in Marketplace, but in `README.md` too. So, people would have imagination about theme look on GitHub too.